### PR TITLE
redesign posts page

### DIFF
--- a/app/(site)/page.tsx
+++ b/app/(site)/page.tsx
@@ -13,6 +13,7 @@ import { HeroSimple } from "@/components/hero-simple";
 import { HeroVideo } from "@/components/hero-video";
 import { Sidebar } from "@/components/home-sidebar";
 import { Mdx } from "@/components/mdx-components";
+import PostPreview from "@/components/post-preview";
 
 async function getAboutPage() {
   const page = allPages.find((page) => page.slug === "about");
@@ -41,25 +42,9 @@ export default async function Home() {
       <div className="container mt-12 max-w-6xl">
         <div className="grid grid-cols-1 place-items-start justify-between gap-12 lg:grid-cols-3">
           <div className="col-span-1 lg:col-span-2">
-            <div className="prose grid grid-flow-row gap-3">
+            <div className="grid grid-flow-row gap-2">
               {posts.map((post) => (
-                <article key={post._id} className="w-full">
-                  <Link
-                    href={`posts/${post.slug}`}
-                    className={cn(
-                      "select-rounded-md block w-full rounded-md px-3 py-6 leading-none no-underline outline-none transition hover:bg-foreground/20 hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-                    )}
-                  >
-                    <h2 className="m-0 text-2xl font-bold leading-none text-foreground">{post.title}</h2>
-                    <div className="mb-4 mt-1 text-sm leading-snug text-muted-foreground">
-                      <time dateTime={post.publishedDate}>{format(parseISO(post.publishedDate), "LLLL d, yyyy")}</time>
-                      <span>{` // ${post.readTimeMinutes} mins read`}</span>
-                    </div>
-                    {post.description && (
-                      <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">{post.description}</p>
-                    )}
-                  </Link>
-                </article>
+                <PostPreview key={post._id} post={post} />
               ))}
             </div>
             <Link

--- a/app/(site)/posts/page.tsx
+++ b/app/(site)/posts/page.tsx
@@ -2,9 +2,10 @@ import { Metadata } from "next";
 import Link from "next/link";
 import { allPosts } from "@/.contentlayer/generated";
 import { compareDesc, format, parseISO } from "date-fns";
-
+import { CalendarDays, Timer } from "lucide-react";
 import { defaultAuthor } from "@/lib/metadata";
 import { cn } from "@/lib/utils";
+import PostPreview from "@/components/post-preview";
 
 export async function generateMetadata(): Promise<Metadata> {
   return {
@@ -20,29 +21,13 @@ export default function Blog() {
       compareDesc(new Date(a.lastUpdatedDate || a.publishedDate), new Date(b.lastUpdatedDate || b.publishedDate))
     );
   return (
-    <div className="container">
-      <div className="prose mx-auto max-w-5xl dark:prose-invert prose-headings:mb-3 prose-headings:mt-8 prose-headings:font-heading prose-headings:font-bold prose-headings:leading-tight hover:prose-a:text-accent-foreground prose-a:prose-headings:no-underline">
-        <h1 className="mt-0 ">Latest Posts</h1>
+    <div className="container mb-4">
+      <div className="prose mx-auto max-w-5xl dark:prose-invert prose-headings:font-heading prose-headings:font-bold prose-headings:leading-tight hover:prose-a:text-accent-foreground prose-a:prose-headings:no-underline">
+        <h1 className="mt-0">Latest Posts</h1>
         <hr className="my-4" />
-        <div className="grid grid-flow-row gap-3">
+        <div className="grid grid-flow-row gap-2">
           {posts.map((post) => (
-            <article key={post._id} className="w-full">
-              <Link
-                href={`posts/${post.slug}`}
-                className={cn(
-                  "select-rounded-md block w-full rounded-md px-2 py-4 leading-none no-underline outline-none transition-colors hover:bg-foreground/20 hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
-                )}
-              >
-                <h3 className="m-0 text-2xl font-bold leading-none text-foreground">{post.title}</h3>
-                <div className="mb-4 mt-1 text-sm leading-snug text-muted-foreground">
-                  <time dateTime={post.publishedDate}>{format(parseISO(post.publishedDate), "LLLL d, yyyy")}</time>
-                  <span>{` // ${post.readTimeMinutes} mins read`}</span>
-                </div>
-                {post.description && (
-                  <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">{post.description}</p>
-                )}
-              </Link>
-            </article>
+            <PostPreview post={post} key={post._id} />
           ))}
         </div>
       </div>

--- a/components/post-preview.tsx
+++ b/components/post-preview.tsx
@@ -1,0 +1,49 @@
+import { Post } from "@/.contentlayer/generated"
+import { CalendarDays, Timer } from "lucide-react"
+import Link from "next/link"
+import { cn } from "@/lib/utils"
+import { format, parseISO } from "date-fns"
+
+type PostPreviewProps = {
+  post: Post
+}
+
+const PostPreview = ({ post }: PostPreviewProps) => {
+  return (
+    <article className="w-full">
+    <Link
+      href={`posts/${post.slug}`}
+      className={cn(
+        "select-rounded-md block w-full rounded-md p-4 leading-none no-underline outline-none transition-colors hover:bg-foreground/10 hover:text-accent-foreground focus:bg-accent focus:text-accent-foreground"
+      )}
+    >
+      <h3 className="text-2xl font-bold text-foreground my-2">{post.title}</h3>
+      <div className="text-sm leading-snug text-muted-foreground flex gap-2">
+        <div className="flex gap-1 items-center">
+          <CalendarDays size={16} />
+          <time dateTime={post.publishedDate}>{format(parseISO(post.publishedDate), "LLLL d, yyyy")}</time>
+        </div>
+        <span className="opacity-50">|</span>
+        <div className="flex gap-1 items-center">
+          <Timer size={16} />
+          <span>{`${post.readTimeMinutes} mins read`}</span>
+        </div>
+      </div>
+      { post?.tags && 
+        <ul className="flex flex-wrap gap-2 p-0 my-4">
+          { post.tags.map((tag: any) => (
+          <li className="inline-block list-none border rounded-full border-muted-foreground/50 px-3 py-1 text-xs text-muted-foreground m-0 bg-muted-foreground/10" key={tag.trim()}>
+            {tag}
+          </li>
+          ))}
+        </ul>
+      }
+      {post.description && (
+        <p className="line-clamp-2 text-sm leading-snug text-muted-foreground">{post.description}</p>
+      )}
+    </Link>
+  </article>
+  )
+}
+
+export default PostPreview


### PR DESCRIPTION
- create a reusable post preview component
- add taglist to previews
- add icons to date and read time

<img width="1086" alt="posts" src="https://github.com/thedevdavid/digital-garden/assets/104263751/e0e15072-b903-40f6-a695-59f06204761f">
