### PR TITLE
feat: X (twitter) update & brand icon imports

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Importing brand icons from simple-icons
+- Using "X (formerly Twitter)" as the name of the X user profile link
+
+### Fixed
+
+- Selecting X social link based on name X instead of twitter
+
 ## [0.7.2] - 2023-09-02
 
 ### Changed

--- a/components/command-dialog.tsx
+++ b/components/command-dialog.tsx
@@ -3,8 +3,9 @@
 import * as React from "react";
 import { useRouter } from "next/navigation";
 import { DialogProps } from "@radix-ui/react-alert-dialog";
-import { File, Github, Laptop, Mail, Moon, Sun, Twitter } from "lucide-react";
+import { File, Laptop, Mail, Moon, Sun } from "lucide-react";
 import { useTheme } from "next-themes";
+import { siGithub, siX } from "simple-icons";
 
 import siteMetadata, { defaultAuthor } from "@/lib/metadata";
 import { navigationLinks } from "@/lib/navigation-links";
@@ -101,12 +102,20 @@ export function CommandDialogComponent({ ...props }: DialogProps) {
             <CommandItem
               onSelect={() => {
                 runCommand(() =>
-                  navigate(defaultAuthor.socialProfiles.find((platform) => platform.name === "twitter")?.link as string)
+                  navigate(defaultAuthor.socialProfiles.find((platform) => platform.name === "x")?.link as string)
                 );
               }}
             >
-              <Twitter className="mr-2 h-4 w-4" />
-              <span>Twitter</span>
+              <svg
+                role="img"
+                viewBox="0 0 24 24"
+                className="mr-2 h-4 w-4"
+                fill="currentColor"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d={siX.path}></path>
+              </svg>
+              <span>X (formerly Twitter)</span>
             </CommandItem>
             <CommandItem
               onSelect={() => {
@@ -115,7 +124,15 @@ export function CommandDialogComponent({ ...props }: DialogProps) {
                 );
               }}
             >
-              <Github className="mr-2 h-4 w-4" />
+              <svg
+                role="img"
+                viewBox="0 0 24 24"
+                className="mr-2 h-4 w-4"
+                fill="currentColor"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path d={siGithub.path}></path>
+              </svg>
               <span>Github</span>
             </CommandItem>
           </CommandGroup>

--- a/components/social-share.tsx
+++ b/components/social-share.tsx
@@ -42,7 +42,7 @@ export const SocialShare = ({ url, text }: SocialShareProps) => {
             >
               <path d={siTwitter.path}></path>
             </svg>
-            Twitter
+            X (formerly Twitter)
           </Link>
         </DropdownMenuItem>
         <DropdownMenuItem asChild>


### PR DESCRIPTION
### Changed

- Importing brand icons from simple-icons
- Using "X (formerly Twitter)" as the name of the X user profile link

### Fixed

- Selecting X social link based on name X instead of twitter

<img width="614" alt="Screenshot 2024-01-22 at 16 29 25" src="https://github.com/thedevdavid/digital-garden/assets/11165169/a8637730-99cb-4ff7-98c7-879ba54700bd">
